### PR TITLE
Add simple frontend and ignore env file

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ JSON containing the solfège notation.
 
 You can also open `index.html` in a browser to record or upload an audio file
 and see the transcription using the frontend.
+
+## GitHub Pages
+
+The repository includes a workflow in `.github/workflows/pages.yml` that
+publishes the static frontend through GitHub Pages. Once Pages is enabled in
+the repository settings and "GitHub Actions" is chosen as the source, every
+push to `main` will deploy the latest `index.html` and `script.js` files.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ pip install -r requirements.txt
 2. Download an Onsets & Frames checkpoint and set `ONSETS_FRAMES_CKPT` to the
    path of the checkpoint file.
 
-3. Provide your OpenAI API key via `OPENAI_API_KEY` environment variable.
+3. Create a `.env` file with your OpenAI API key:
+
+   ```bash
+   echo "OPENAI_API_KEY=YOUR_KEY" > .env
+   ```
 
 ## Running the server
 
@@ -28,3 +32,6 @@ uvicorn main:app --reload
 
 Then POST an MP3 file to `http://localhost:8000/transcribe/` and you will get
 JSON containing the solfège notation.
+
+You can also open `index.html` in a browser to record or upload an audio file
+and see the transcription using the frontend.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Solconverter Test</title>
+</head>
+<body>
+    <h1>Solconverter</h1>
+    <input type="file" id="fileInput" accept="audio/mpeg,audio/wav" />
+    <button id="recordBtn">Record</button>
+    <button id="stopBtn" disabled>Stop</button>
+    <button id="uploadBtn">Upload</button>
+    <pre id="output"></pre>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,60 @@
+let mediaRecorder;
+let recordedChunks = [];
+
+const recordBtn = document.getElementById('recordBtn');
+const stopBtn = document.getElementById('stopBtn');
+const uploadBtn = document.getElementById('uploadBtn');
+const fileInput = document.getElementById('fileInput');
+const output = document.getElementById('output');
+
+recordBtn.onclick = async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    mediaRecorder = new MediaRecorder(stream);
+    recordedChunks = [];
+    mediaRecorder.ondataavailable = e => {
+        if (e.data.size > 0) recordedChunks.push(e.data);
+    };
+    mediaRecorder.onstop = () => {
+        stream.getTracks().forEach(t => t.stop());
+    };
+    mediaRecorder.start();
+    recordBtn.disabled = true;
+    stopBtn.disabled = false;
+};
+
+stopBtn.onclick = () => {
+    mediaRecorder.stop();
+    recordBtn.disabled = false;
+    stopBtn.disabled = true;
+};
+
+uploadBtn.onclick = async () => {
+    let blob;
+    if (recordedChunks.length) {
+        blob = new Blob(recordedChunks, { type: 'audio/mpeg' });
+    } else if (fileInput.files[0]) {
+        blob = fileInput.files[0];
+    } else {
+        alert('No file or recording.');
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', blob, 'audio.mp3');
+
+    output.textContent = 'Uploading...';
+
+    try {
+        const resp = await fetch('/transcribe/', {
+            method: 'POST',
+            body: formData
+        });
+        if (!resp.ok) {
+            throw new Error(await resp.text());
+        }
+        const data = await resp.json();
+        output.textContent = data.notation;
+    } catch (err) {
+        output.textContent = err;
+    }
+};


### PR DESCRIPTION
## Summary
- ignore `.env` so API keys stay local
- add `index.html` and `script.js` for browser-based recording/upload
- document `.env` usage and frontend in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6859555949a4832c8fe74e1bc1dd5374